### PR TITLE
Add interactive rosary prayer bead tracker tab

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -30,6 +30,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="rosary"
+        options={{
+          title: 'Terços',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="circle.grid.3x3.fill" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/rosary.tsx
+++ b/app/(tabs)/rosary.tsx
@@ -1,0 +1,157 @@
+import { StyleSheet } from 'react-native';
+
+import ParallaxScrollView from '@/components/parallax-scroll-view';
+import { PrayerBeadTracker, type PrayerSequence } from '@/components/prayer-bead-tracker';
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Fonts } from '@/constants/theme';
+
+const rosarySequence: PrayerSequence = {
+  id: 'dominican-rosary',
+  name: 'Santo Rosário',
+  description: 'Acompanhe cada conta do rosário dominicano, marcando Pai-Nossos, Ave-Marias e orações finais.',
+  sections: [
+    {
+      title: 'Abertura',
+      description:
+        'Inicie com o Sinal da Cruz, reze o Credo, um Pai-Nosso, três Ave-Marias e o Glória ao Pai.',
+      beads: [
+        { id: 'rosary-opening-cross', label: 'Sinal da Cruz', type: 'marker' },
+        { id: 'rosary-opening-creed', label: 'Credo dos Apóstolos', type: 'large' },
+        { id: 'rosary-opening-our-father', label: 'Pai-Nosso', type: 'large' },
+        { id: 'rosary-opening-hail-1', label: 'Ave-Maria 1', type: 'small' },
+        { id: 'rosary-opening-hail-2', label: 'Ave-Maria 2', type: 'small' },
+        { id: 'rosary-opening-hail-3', label: 'Ave-Maria 3', type: 'small' },
+        { id: 'rosary-opening-glory', label: 'Glória ao Pai', type: 'marker' },
+      ],
+    },
+    ...Array.from({ length: 5 }, (_, index) => {
+      const decadeNumber = index + 1;
+      return {
+        title: `Dezena ${decadeNumber}`,
+        description:
+          'Medite no mistério correspondente, reze um Pai-Nosso, dez Ave-Marias e o Glória ao Pai.',
+        beads: [
+          {
+            id: `rosary-decade-${decadeNumber}-our-father`,
+            label: 'Pai-Nosso',
+            type: 'large',
+          },
+          ...Array.from({ length: 10 }, (_, beadIndex) => ({
+            id: `rosary-decade-${decadeNumber}-hail-${beadIndex + 1}`,
+            label: `Ave-Maria ${beadIndex + 1}`,
+            type: 'small',
+          })),
+          {
+            id: `rosary-decade-${decadeNumber}-glory`,
+            label: 'Glória ao Pai',
+            type: 'marker',
+          },
+        ],
+      };
+    }),
+    {
+      title: 'Conclusão',
+      description: 'Reze a Salve Rainha e as jaculatórias finais.',
+      beads: [
+        { id: 'rosary-closing-hail-holy-queen', label: 'Salve Rainha', type: 'marker' },
+        { id: 'rosary-closing-final-prayers', label: 'Orações finais', type: 'marker' },
+      ],
+    },
+  ],
+};
+
+const divineMercySequence: PrayerSequence = {
+  id: 'divine-mercy-chaplet',
+  name: 'Terço da Divina Misericórdia',
+  description: 'Use as contas do rosário para acompanhar as invocações da Divina Misericórdia.',
+  sections: [
+    {
+      title: 'Abertura',
+      description: 'Sinal da Cruz seguido de um Pai-Nosso, uma Ave-Maria e o Credo.',
+      beads: [
+        { id: 'mercy-opening-cross', label: 'Sinal da Cruz', type: 'marker' },
+        { id: 'mercy-opening-our-father', label: 'Pai-Nosso', type: 'large' },
+        { id: 'mercy-opening-hail-mary', label: 'Ave-Maria', type: 'small' },
+        { id: 'mercy-opening-creed', label: 'Creio', type: 'large' },
+      ],
+    },
+    ...Array.from({ length: 5 }, (_, index) => {
+      const decadeNumber = index + 1;
+      return {
+        title: `Dezena ${decadeNumber}`,
+        description:
+          'No Pai-Nosso reze “Eterno Pai...” e nas dez contas pequenas repita “Pela sua dolorosa Paixão...”.',
+        beads: [
+          {
+            id: `mercy-decade-${decadeNumber}-eternal-father`,
+            label: 'Eterno Pai',
+            type: 'large',
+          },
+          ...Array.from({ length: 10 }, (_, beadIndex) => ({
+            id: `mercy-decade-${decadeNumber}-passion-${beadIndex + 1}`,
+            label: `Paixão ${beadIndex + 1}`,
+            type: 'small',
+          })),
+        ],
+      };
+    }),
+    {
+      title: 'Conclusão',
+      description: 'Finalize com “Santo Deus” (três vezes) e as orações opcionais.',
+      beads: [
+        { id: 'mercy-closing-holy-god-1', label: 'Santo Deus 1', type: 'marker' },
+        { id: 'mercy-closing-holy-god-2', label: 'Santo Deus 2', type: 'marker' },
+        { id: 'mercy-closing-holy-god-3', label: 'Santo Deus 3', type: 'marker' },
+        { id: 'mercy-closing-final-prayer', label: 'Oração final', type: 'marker' },
+      ],
+    },
+  ],
+};
+
+export default function RosaryScreen() {
+  return (
+    <ParallaxScrollView
+      headerBackgroundColor={{ light: '#F4E9F7', dark: '#1F1527' }}
+      headerImage={
+        <IconSymbol
+          size={320}
+          color="#B47BC7"
+          name="circle.grid.3x3.fill"
+          style={styles.headerIcon}
+        />
+      }>
+      <ThemedView style={styles.titleContainer}>
+        <ThemedText type="title" style={[styles.title, { fontFamily: Fonts.rounded }]}>
+          Contador de Terços
+        </ThemedText>
+        <ThemedText style={styles.lead}>
+          Marque cada conta enquanto reza o Santo Rosário ou o Terço da Divina Misericórdia. O progresso fica visível em cada seção, facilitando retomar a oração caso se distraia.
+        </ThemedText>
+      </ThemedView>
+
+      <PrayerBeadTracker sequence={rosarySequence} />
+      <PrayerBeadTracker sequence={divineMercySequence} />
+    </ParallaxScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerIcon: {
+    position: 'absolute',
+    bottom: -80,
+    left: -20,
+    opacity: 0.2,
+  },
+  titleContainer: {
+    gap: 12,
+    marginBottom: 24,
+  },
+  title: {
+    fontFamily: Fonts.rounded,
+  },
+  lead: {
+    lineHeight: 22,
+  },
+});

--- a/components/prayer-bead-tracker.tsx
+++ b/components/prayer-bead-tracker.tsx
@@ -1,0 +1,252 @@
+import { useMemo, useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+
+import { Fonts } from '@/constants/theme';
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+import { ThemedText } from './themed-text';
+import { ThemedView } from './themed-view';
+
+type PrayerBeadType = 'marker' | 'large' | 'small';
+
+type PrayerBead = {
+  id: string;
+  label: string;
+  type: PrayerBeadType;
+};
+
+type PrayerSection = {
+  title: string;
+  description?: string;
+  beads: PrayerBead[];
+};
+
+type PrayerSequence = {
+  id: string;
+  name: string;
+  description: string;
+  sections: PrayerSection[];
+};
+
+type PrayerBeadTrackerProps = {
+  sequence: PrayerSequence;
+};
+
+export function PrayerBeadTracker({ sequence }: PrayerBeadTrackerProps) {
+  const accentColor = useThemeColor({}, 'tint');
+  const iconColor = useThemeColor({}, 'icon');
+  const textColor = useThemeColor({}, 'text');
+  const backgroundColor = useThemeColor({}, 'background');
+  const markerIdleColor = useThemeColor({ light: '#E5ECF6', dark: '#1E2732' }, 'background');
+
+  const totalBeads = useMemo(
+    () => sequence.sections.reduce((total, section) => total + section.beads.length, 0),
+    [sequence.sections]
+  );
+
+  const [markedBeads, setMarkedBeads] = useState<Set<string>>(new Set());
+
+  const toggleBead = (beadId: string) => {
+    setMarkedBeads((current) => {
+      const updated = new Set(current);
+      if (updated.has(beadId)) {
+        updated.delete(beadId);
+      } else {
+        updated.add(beadId);
+      }
+      return updated;
+    });
+  };
+
+  const reset = () => {
+    setMarkedBeads(new Set());
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <View style={styles.header}>
+        <ThemedText type="subtitle" style={[styles.title, { fontFamily: Fonts.serif }] }>
+          {sequence.name}
+        </ThemedText>
+        <ThemedText style={styles.description}>{sequence.description}</ThemedText>
+        <View style={styles.progressRow}>
+          <View style={styles.progressIndicator}>
+            <View
+              style={[
+                styles.progressFill,
+                { width: `${(markedBeads.size / totalBeads) * 100}%`, backgroundColor: accentColor },
+              ]}
+            />
+          </View>
+          <ThemedText style={styles.progressText}>
+            {markedBeads.size} / {totalBeads} contas
+          </ThemedText>
+          <Pressable onPress={reset} style={styles.resetButton} accessibilityRole="button">
+            {({ pressed }) => (
+              <ThemedText
+                type="defaultSemiBold"
+                style={[
+                  styles.resetLabel,
+                  { color: accentColor },
+                  pressed && { opacity: 0.6 },
+                ]}>
+                Reiniciar
+              </ThemedText>
+            )}
+          </Pressable>
+        </View>
+      </View>
+
+      <View style={styles.sections}>
+        {sequence.sections.map((section) => (
+          <View key={section.title} style={styles.section}>
+            <ThemedText style={[styles.sectionTitle, { fontFamily: Fonts.rounded }]}>
+              {section.title}
+            </ThemedText>
+            {section.description ? (
+              <ThemedText style={styles.sectionDescription}>{section.description}</ThemedText>
+            ) : null}
+            <View style={styles.beadRow}>
+              {section.beads.map((bead) => {
+                const isMarked = markedBeads.has(bead.id);
+
+                return (
+                  <Pressable
+                    key={bead.id}
+                    onPress={() => toggleBead(bead.id)}
+                    style={({ pressed }) => [
+                      styles.bead,
+                      bead.type === 'small' && styles.smallBead,
+                      bead.type === 'large' && styles.largeBead,
+                      bead.type === 'marker' && styles.markerBead,
+                      {
+                        borderColor: isMarked ? accentColor : iconColor,
+                        backgroundColor: isMarked
+                          ? accentColor
+                          : bead.type === 'marker'
+                            ? markerIdleColor
+                            : backgroundColor,
+                      },
+                      pressed && { opacity: 0.7 },
+                    ]}
+                    accessibilityLabel={bead.label}
+                    accessibilityRole="checkbox"
+                    accessibilityState={{ checked: isMarked }}
+                  />
+                );
+              })}
+            </View>
+            <View style={styles.beadLabels}>
+              {section.beads.map((bead) => (
+                <ThemedText
+                  key={`${bead.id}-label`}
+                  style={[styles.beadLabel, { color: textColor }]}
+                  numberOfLines={1}>
+                  {bead.label}
+                </ThemedText>
+              ))}
+            </View>
+          </View>
+        ))}
+      </View>
+    </ThemedView>
+  );
+}
+
+export type { PrayerBead, PrayerSection, PrayerSequence };
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 18,
+    padding: 18,
+    marginBottom: 24,
+    gap: 16,
+    elevation: 1,
+    shadowColor: '#00000025',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.12,
+    shadowRadius: 12,
+  },
+  header: {
+    gap: 8,
+  },
+  title: {
+    fontSize: 22,
+  },
+  description: {
+    lineHeight: 22,
+  },
+  progressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  progressIndicator: {
+    flex: 1,
+    height: 8,
+    borderRadius: 999,
+    backgroundColor: '#00000012',
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+  },
+  progressText: {
+    minWidth: 90,
+    textAlign: 'center',
+    fontFamily: Fonts.mono,
+  },
+  resetButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+  },
+  resetLabel: {
+    fontSize: 14,
+  },
+  sections: {
+    gap: 20,
+  },
+  section: {
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 18,
+  },
+  sectionDescription: {
+    lineHeight: 20,
+    color: '#687076',
+  },
+  beadRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  bead: {
+    borderWidth: 2,
+    borderRadius: 999,
+    width: 28,
+    height: 28,
+  },
+  smallBead: {
+    width: 22,
+    height: 22,
+  },
+  largeBead: {
+    width: 28,
+    height: 28,
+  },
+  markerBead: {
+    width: 32,
+    height: 32,
+  },
+  beadLabels: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  beadLabel: {
+    fontSize: 12,
+    maxWidth: 70,
+  },
+});

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'circle.grid.3x3.fill': 'apps',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- add a new Rosary tab featuring trackers for the Santo Rosário and Terço da Divina Misericórdia
- implement a reusable prayer bead tracker component with progress, reset, and accessibility support
- register the Rosary tab icon mapping for consistent tab navigation visuals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ebcf72d74c832789c87d1a6f36a35a