### PR TITLE
Add daily rosary mysteries and bilingual prayers

### DIFF
--- a/app/(tabs)/rosary.tsx
+++ b/app/(tabs)/rosary.tsx
@@ -7,6 +7,100 @@ import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { Fonts } from '@/constants/theme';
 
+const dailyMysteries = [
+  {
+    id: 'joyful',
+    title: 'Mistérios Gozosos',
+    days: 'Segunda-feira e Sábado',
+    mysteries: [
+      '1º A Anunciação do Anjo Gabriel a Maria',
+      '2º A visitação de Maria a Santa Isabel',
+      '3º O nascimento de Jesus em Belém',
+      '4º A apresentação de Jesus no Templo',
+      '5º O reencontro de Jesus no Templo',
+    ],
+  },
+  {
+    id: 'sorrowful',
+    title: 'Mistérios Dolorosos',
+    days: 'Terça-feira e Sexta-feira',
+    mysteries: [
+      '1º A agonia de Jesus no Horto',
+      '2º A flagelação de Jesus atado à coluna',
+      '3º A coroação de espinhos',
+      '4º Jesus carrega a cruz até o Calvário',
+      '5º A crucifixão e morte de Jesus',
+    ],
+  },
+  {
+    id: 'glorious',
+    title: 'Mistérios Gloriosos',
+    days: 'Quarta-feira e Domingo',
+    mysteries: [
+      '1º A ressurreição do Senhor',
+      '2º A ascensão de Jesus aos céus',
+      '3º A vinda do Espírito Santo em Pentecostes',
+      '4º A assunção de Maria ao céu',
+      '5º A coroação de Maria como Rainha do Céu e da Terra',
+    ],
+  },
+  {
+    id: 'luminous',
+    title: 'Mistérios Luminosos',
+    days: 'Quinta-feira',
+    mysteries: [
+      '1º O Batismo de Jesus no Jordão',
+      '2º As Bodas de Caná',
+      '3º O anúncio do Reino de Deus com o convite à conversão',
+      '4º A Transfiguração de Jesus',
+      '5º A instituição da Eucaristia',
+    ],
+  },
+];
+
+const bilingualPrayers = [
+  {
+    id: 'salve-rainha',
+    title: 'Salve Rainha',
+    portuguese:
+      'Salve, Rainha, Mãe de misericórdia; vida, doçura e esperança nossa, salve. A vós bradamos, os degredados filhos de Eva. A vós suspiramos, gemendo e chorando neste vale de lágrimas. Eia, pois, advogada nossa, esses vossos olhos misericordiosos a nós volvei. E depois deste desterro, mostrai-nos Jesus, bendito fruto do vosso ventre. Ó clemente, ó piedosa, ó doce sempre Virgem Maria. Rogai por nós, santa Mãe de Deus, para que sejamos dignos das promessas de Cristo. Amém.',
+    latin:
+      'Salve, Regina, mater misericordiae; vita, dulcedo, et spes nostra, salve. Ad te clamamus, exsules filii Hevae. Ad te suspiramus, gementes et flentes in hac lacrimarum valle. Eia ergo, advocata nostra, illos tuos misericordes oculos ad nos converte. Et Iesum, benedictum fructum ventris tui, nobis post hoc exsilium ostende. O clemens, O pia, O dulcis Virgo Maria. Ora pro nobis, sancta Dei Genetrix, ut digni efficiamur promissionibus Christi. Amen.',
+  },
+  {
+    id: 'magnificat',
+    title: 'Magnificat',
+    portuguese:
+      'A minha alma engrandece o Senhor, e o meu espírito se alegra em Deus, meu Salvador; porque olhou para a humildade de sua serva; doravante todas as gerações me chamarão bem-aventurada; porque o Poderoso fez em mim maravilhas, e Santo é o seu nome. Sua misericórdia se estende, de geração em geração, sobre os que o temem. Manifestou o poder do seu braço: dispersou os soberbos de coração. Derrubou do trono os poderosos e exaltou os humildes. Encheu de bens os famintos, e despediu os ricos de mãos vazias. Acolheu Israel, seu servo, lembrado de sua misericórdia, conforme prometera aos nossos pais, em favor de Abraão e de sua descendência, para sempre. Amém.',
+    latin:
+      'Magnificat anima mea Dominum; et exsultavit spiritus meus in Deo salutari meo, quia respexit humilitatem ancillae suae. Ecce enim ex hoc beatam me dicent omnes generationes, quia fecit mihi magna qui potens est, et sanctum nomen eius, et misericordia eius in progenies et progenies timentibus eum. Fecit potentiam in brachio suo; dispersit superbos mente cordis sui. Deposuit potentes de sede et exaltavit humiles. Esurientes implevit bonis et divites dimisit inanes. Suscepit Israel puerum suum, recordatus misericordiae suae, sicut locutus est ad patres nostros, Abraham et semini eius in saecula. Amen.',
+  },
+  {
+    id: 'pater-noster',
+    title: 'Pai-Nosso (Pater Noster)',
+    portuguese:
+      'Pai nosso que estais no céu, santificado seja o vosso nome; venha a nós o vosso reino; seja feita a vossa vontade, assim na terra como no céu; o pão nosso de cada dia nos dai hoje; perdoai-nos as nossas ofensas, assim como nós perdoamos a quem nos tem ofendido; e não nos deixeis cair em tentação, mas livrai-nos do mal. Amém.',
+    latin:
+      'Pater noster, qui es in caelis, sanctificetur nomen tuum; adveniat regnum tuum; fiat voluntas tua, sicut in caelo et in terra. Panem nostrum quotidianum da nobis hodie; et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris; et ne nos inducas in tentationem; sed libera nos a malo. Amen.',
+  },
+  {
+    id: 'ave-maria',
+    title: 'Ave-Maria',
+    portuguese:
+      'Ave Maria, cheia de graça, o Senhor é convosco; bendita sois vós entre as mulheres, e bendito é o fruto do vosso ventre, Jesus. Santa Maria, Mãe de Deus, rogai por nós, pecadores, agora e na hora de nossa morte. Amém.',
+    latin:
+      'Ave Maria, gratia plena, Dominus tecum; benedicta tu in mulieribus, et benedictus fructus ventris tui, Iesus. Sancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.',
+  },
+  {
+    id: 'gloria-patri',
+    title: 'Glória ao Pai (Gloria Patri)',
+    portuguese:
+      'Glória ao Pai, ao Filho e ao Espírito Santo. Como era no princípio, agora e sempre. Amém.',
+    latin:
+      'Gloria Patri, et Filio, et Spiritui Sancto. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.',
+  },
+];
+
 const rosarySequence: PrayerSequence = {
   id: 'dominican-rosary',
   name: 'Santo Rosário',
@@ -133,6 +227,88 @@ export default function RosaryScreen() {
 
       <PrayerBeadTracker sequence={rosarySequence} />
       <PrayerBeadTracker sequence={divineMercySequence} />
+
+      <ThemedView style={styles.section}>
+        <ThemedText
+          type="subtitle"
+          style={[styles.sectionTitle, { fontFamily: Fonts.serif }]}
+        >
+          Mistérios do Santo Terço por dia
+        </ThemedText>
+        <ThemedText style={styles.sectionDescription}>
+          Consulte rapidamente quais mistérios contemplar em cada dia da semana e mantenha a
+          meditação unida às intenções da Igreja.
+        </ThemedText>
+
+        {dailyMysteries.map((entry) => (
+          <ThemedView
+            key={entry.id}
+            style={styles.infoCard}
+            lightColor="#F5EFFA"
+            darkColor="#1F1527"
+          >
+            <ThemedText
+              type="subtitle"
+              style={[styles.infoTitle, { fontFamily: Fonts.serif }]}
+            >
+              {entry.title}
+            </ThemedText>
+            <ThemedText style={styles.infoDays}>{entry.days}</ThemedText>
+            {entry.mysteries.map((mystery) => (
+              <ThemedText key={mystery} style={styles.listItem}>
+                {mystery}
+              </ThemedText>
+            ))}
+          </ThemedView>
+        ))}
+      </ThemedView>
+
+      <ThemedView style={styles.section}>
+        <ThemedText
+          type="subtitle"
+          style={[styles.sectionTitle, { fontFamily: Fonts.serif }]}
+        >
+          Orações em Português e Latim
+        </ThemedText>
+        <ThemedText style={styles.sectionDescription}>
+          Reze nas duas línguas tradicionais da Igreja: memorize, acompanhe o áudio do seu
+          diretor espiritual ou partilhe com o seu grupo de oração.
+        </ThemedText>
+
+        {bilingualPrayers.map((prayer) => (
+          <ThemedView
+            key={prayer.id}
+            style={styles.prayerCard}
+            lightColor="#F2F7F5"
+            darkColor="#0F1D1A"
+          >
+            <ThemedText
+              type="subtitle"
+              style={[styles.prayerTitle, { fontFamily: Fonts.serif }]}
+            >
+              {prayer.title}
+            </ThemedText>
+
+            <ThemedText
+              style={styles.languageLabel}
+              lightColor="#356859"
+              darkColor="#9FE2BF"
+            >
+              Português
+            </ThemedText>
+            <ThemedText style={styles.prayerText}>{prayer.portuguese}</ThemedText>
+
+            <ThemedText
+              style={styles.languageLabel}
+              lightColor="#356859"
+              darkColor="#9FE2BF"
+            >
+              Latim
+            </ThemedText>
+            <ThemedText style={styles.prayerText}>{prayer.latin}</ThemedText>
+          </ThemedView>
+        ))}
+      </ThemedView>
     </ParallaxScrollView>
   );
 }
@@ -152,6 +328,47 @@ const styles = StyleSheet.create({
     fontFamily: Fonts.rounded,
   },
   lead: {
+    lineHeight: 22,
+  },
+  section: {
+    marginTop: 32,
+    gap: 16,
+  },
+  sectionTitle: {
+    fontSize: 22,
+  },
+  sectionDescription: {
+    lineHeight: 22,
+  },
+  infoCard: {
+    padding: 18,
+    borderRadius: 16,
+    gap: 8,
+  },
+  infoTitle: {
+    fontSize: 18,
+  },
+  infoDays: {
+    fontWeight: '600',
+  },
+  listItem: {
+    lineHeight: 22,
+  },
+  prayerCard: {
+    padding: 18,
+    borderRadius: 16,
+    gap: 8,
+  },
+  prayerTitle: {
+    fontSize: 18,
+  },
+  languageLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  prayerText: {
     lineHeight: 22,
   },
 });


### PR DESCRIPTION
## Summary
- add daily schedule cards describing the mysteries of the Rosary for each day of the week
- include bilingual (Portuguese and Latin) versions of traditional Marian and common prayers on the Rosary screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ebd53c86f08327ab6ccbd363b91839