### PR TITLE
Fix chat layout to keep composer visible

### DIFF
--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -219,6 +219,7 @@ export default function ChatScreen() {
             data={messages}
             keyExtractor={(item) => item.id}
             renderItem={renderMessage}
+            style={styles.list}
             contentContainerStyle={styles.listContent}
             ListHeaderComponent={headerComponent}
             onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: true })}
@@ -275,7 +276,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  list: {
+    flex: 1,
+  },
   listContent: {
+    flexGrow: 1,
     paddingHorizontal: 20,
     paddingBottom: 24,
   },


### PR DESCRIPTION
## Summary
- give the chat list flex layout so it shares the screen with the composer
- ensure the list content can grow to occupy the remaining space, preventing the composer from being pushed off-screen

## Testing
- npm run web *(fails: Expo CLI cannot fetch dependencies in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebde181ab08327b1fb3c7bf7626f58