### PR TITLE
Fix catechist tab icon mapping

### DIFF
--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -20,6 +20,7 @@ const MAPPING = {
   'chevron.right': 'chevron-right',
   'circle.grid.3x3.fill': 'apps',
   'bubble.left.and.bubble.right.fill': 'forum',
+  'book.fill': 'menu-book',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- add Material icon fallback for the catechist tab symbol so it renders on all platforms

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee9dfdec108327a846dcc67a2bfabe