### PR TITLE
Move catechist setup guide to Explore tab

### DIFF
--- a/app/(tabs)/catechist.tsx
+++ b/app/(tabs)/catechist.tsx
@@ -310,21 +310,9 @@ export default function CatechistScreen() {
         <ThemedText style={styles.description}>
           Integre o agente criado na sua conta OpenAI para responder dúvidas sobre a fé católica com base no livro “A Fé Explicada”.
         </ThemedText>
-        <View style={styles.instructions}>
-          <ThemedText type="defaultSemiBold">Como configurar</ThemedText>
-          <ThemedText style={styles.description}>
-            1. No portal do OpenAI, copie o <ThemedText type="defaultSemiBold">ID do agente</ThemedText> que você criou (Assistants → seu agente → “Agent ID”).
-          </ThemedText>
-          <ThemedText style={styles.description}>
-            2. No Azure Static Web Apps (ou no ambiente onde as funções estão rodando), defina as variáveis <ThemedText type="defaultSemiBold">OPENAI_API_KEY</ThemedText> e <ThemedText type="defaultSemiBold">OPENAI_CATECHIST_AGENT_ID</ThemedText> com os valores correspondentes.
-          </ThemedText>
-          <ThemedText style={styles.description}>
-            3. Se quiser testar em dispositivos físicos, exponha o endpoint configurando <ThemedText type="defaultSemiBold">EXPO_PUBLIC_CATECHIST_BASE_URL</ThemedText> (ou reutilize <ThemedText type="defaultSemiBold">EXPO_PUBLIC_CHAT_BASE_URL</ThemedText>) apontando para a URL pública da Static Web App.
-          </ThemedText>
-          <ThemedText style={styles.description}>
-            4. Publique as alterações. Depois que as funções forem atualizadas, abra esta aba e envie uma mensagem para validar se o agente está respondendo conforme o esperado.
-          </ThemedText>
-        </View>
+        <ThemedText style={styles.description}>
+          Consulte a aba <ThemedText type="defaultSemiBold">Explore</ThemedText> para seguir o passo a passo de configuração do agente antes de iniciar uma conversa.
+        </ThemedText>
         <View
           style={[
             styles.divider,
@@ -436,12 +424,6 @@ const styles = StyleSheet.create({
   description: {
     lineHeight: 22,
     textAlign: 'justify',
-  },
-  instructions: {
-    gap: 8,
-    padding: 12,
-    borderRadius: 12,
-    backgroundColor: '#e0f2fe',
   },
   divider: {
     height: StyleSheet.hairlineWidth,

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -33,6 +33,21 @@ export default function TabTwoScreen() {
         </ThemedText>
       </ThemedView>
 
+      <Collapsible title="Configuração do Assistente Catequista">
+        <ThemedText>
+          1. No portal do OpenAI, copie o <ThemedText type="defaultSemiBold">ID do agente</ThemedText> que você criou (Assistants → seu agente → “Agent ID”).
+        </ThemedText>
+        <ThemedText>
+          2. No Azure Static Web Apps (ou no ambiente onde as funções estão rodando), defina as variáveis <ThemedText type="defaultSemiBold">OPENAI_API_KEY</ThemedText> e <ThemedText type="defaultSemiBold">OPENAI_CATECHIST_AGENT_ID</ThemedText> com os valores correspondentes.
+        </ThemedText>
+        <ThemedText>
+          3. Se quiser testar em dispositivos físicos, exponha o endpoint configurando <ThemedText type="defaultSemiBold">EXPO_PUBLIC_CATECHIST_BASE_URL</ThemedText> (ou reutilize <ThemedText type="defaultSemiBold">EXPO_PUBLIC_CHAT_BASE_URL</ThemedText>) apontando para a URL pública da Static Web App.
+        </ThemedText>
+        <ThemedText>
+          4. Publique as alterações. Depois que as funções forem atualizadas, abra a aba do assistente e envie uma mensagem para validar se o agente está respondendo conforme o esperado.
+        </ThemedText>
+      </Collapsible>
+
       <Collapsible title="Recursos oficiais do Vaticano">
         <ThemedText>
           Orientamos o acesso direto ao portal{' '}


### PR DESCRIPTION
## Summary
- relocate the passo a passo de configuração do Assistente Catequista para a aba Explore
- substituir as instruções na aba Catequista por um aviso que direciona o usuário para a nova seção

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ef180df43483278ff37411cf81d243