### PR TITLE
feat: add prayers tab for bilingual devotions

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -38,6 +38,13 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="prayers"
+        options={{
+          title: 'Orações',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="hands.sparkles.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
         name="catechist"
         options={{
           title: 'Catequista',

--- a/app/(tabs)/prayers.tsx
+++ b/app/(tabs)/prayers.tsx
@@ -1,0 +1,104 @@
+import { StyleSheet } from 'react-native';
+
+import ParallaxScrollView from '@/components/parallax-scroll-view';
+import { IconSymbol } from '@/components/ui/icon-symbol';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { bilingualPrayers } from '@/constants/bilingual-prayers';
+import { Fonts } from '@/constants/theme';
+
+export default function PrayersScreen() {
+  return (
+    <ParallaxScrollView
+      headerBackgroundColor={{ light: '#F9F6EF', dark: '#1B1A14' }}
+      headerImage={
+        <IconSymbol
+          size={320}
+          color="#C0A162"
+          name="hands.sparkles.fill"
+          style={styles.headerIcon}
+        />
+      }>
+      <ThemedView style={styles.titleContainer}>
+        <ThemedText type="title" style={[styles.title, { fontFamily: Fonts.rounded }]}>
+          Orações
+        </ThemedText>
+        <ThemedText style={styles.lead}>
+          Reze nas duas línguas tradicionais da Igreja. Memorize cada texto, acompanhe o seu
+          diretor espiritual ou partilhe com o grupo de oração.
+        </ThemedText>
+      </ThemedView>
+
+      {bilingualPrayers.map((prayer) => (
+        <ThemedView
+          key={prayer.id}
+          style={styles.prayerCard}
+          lightColor="#F2F7F5"
+          darkColor="#0F1D1A"
+        >
+          <ThemedText
+            type="subtitle"
+            style={[styles.prayerTitle, { fontFamily: Fonts.serif }]}
+          >
+            {prayer.title}
+          </ThemedText>
+
+          <ThemedText
+            style={styles.languageLabel}
+            lightColor="#356859"
+            darkColor="#9FE2BF"
+          >
+            Português
+          </ThemedText>
+          <ThemedText style={styles.prayerText}>{prayer.portuguese}</ThemedText>
+
+          <ThemedText
+            style={styles.languageLabel}
+            lightColor="#356859"
+            darkColor="#9FE2BF"
+          >
+            Latim
+          </ThemedText>
+          <ThemedText style={styles.prayerText}>{prayer.latin}</ThemedText>
+        </ThemedView>
+      ))}
+    </ParallaxScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerIcon: {
+    position: 'absolute',
+    bottom: -80,
+    right: -20,
+    opacity: 0.2,
+  },
+  titleContainer: {
+    gap: 12,
+    marginBottom: 24,
+  },
+  title: {
+    fontFamily: Fonts.rounded,
+  },
+  lead: {
+    lineHeight: 22,
+  },
+  prayerCard: {
+    marginTop: 24,
+    padding: 18,
+    borderRadius: 16,
+    gap: 8,
+  },
+  prayerTitle: {
+    fontSize: 18,
+  },
+  languageLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  prayerText: {
+    lineHeight: 22,
+  },
+});

--- a/app/(tabs)/rosary.tsx
+++ b/app/(tabs)/rosary.tsx
@@ -59,49 +59,6 @@ const dailyMysteries = [
   },
 ];
 
-const bilingualPrayers = [
-  {
-    id: 'salve-rainha',
-    title: 'Salve Rainha',
-    portuguese:
-      'Salve, Rainha, Mãe de misericórdia; vida, doçura e esperança nossa, salve. A vós bradamos, os degredados filhos de Eva. A vós suspiramos, gemendo e chorando neste vale de lágrimas. Eia, pois, advogada nossa, esses vossos olhos misericordiosos a nós volvei. E depois deste desterro, mostrai-nos Jesus, bendito fruto do vosso ventre. Ó clemente, ó piedosa, ó doce sempre Virgem Maria. Rogai por nós, santa Mãe de Deus, para que sejamos dignos das promessas de Cristo. Amém.',
-    latin:
-      'Salve, Regina, mater misericordiae; vita, dulcedo, et spes nostra, salve. Ad te clamamus, exsules filii Hevae. Ad te suspiramus, gementes et flentes in hac lacrimarum valle. Eia ergo, advocata nostra, illos tuos misericordes oculos ad nos converte. Et Iesum, benedictum fructum ventris tui, nobis post hoc exsilium ostende. O clemens, O pia, O dulcis Virgo Maria. Ora pro nobis, sancta Dei Genetrix, ut digni efficiamur promissionibus Christi. Amen.',
-  },
-  {
-    id: 'magnificat',
-    title: 'Magnificat',
-    portuguese:
-      'A minha alma engrandece o Senhor, e o meu espírito se alegra em Deus, meu Salvador; porque olhou para a humildade de sua serva; doravante todas as gerações me chamarão bem-aventurada; porque o Poderoso fez em mim maravilhas, e Santo é o seu nome. Sua misericórdia se estende, de geração em geração, sobre os que o temem. Manifestou o poder do seu braço: dispersou os soberbos de coração. Derrubou do trono os poderosos e exaltou os humildes. Encheu de bens os famintos, e despediu os ricos de mãos vazias. Acolheu Israel, seu servo, lembrado de sua misericórdia, conforme prometera aos nossos pais, em favor de Abraão e de sua descendência, para sempre. Amém.',
-    latin:
-      'Magnificat anima mea Dominum; et exsultavit spiritus meus in Deo salutari meo, quia respexit humilitatem ancillae suae. Ecce enim ex hoc beatam me dicent omnes generationes, quia fecit mihi magna qui potens est, et sanctum nomen eius, et misericordia eius in progenies et progenies timentibus eum. Fecit potentiam in brachio suo; dispersit superbos mente cordis sui. Deposuit potentes de sede et exaltavit humiles. Esurientes implevit bonis et divites dimisit inanes. Suscepit Israel puerum suum, recordatus misericordiae suae, sicut locutus est ad patres nostros, Abraham et semini eius in saecula. Amen.',
-  },
-  {
-    id: 'pater-noster',
-    title: 'Pai-Nosso (Pater Noster)',
-    portuguese:
-      'Pai nosso que estais no céu, santificado seja o vosso nome; venha a nós o vosso reino; seja feita a vossa vontade, assim na terra como no céu; o pão nosso de cada dia nos dai hoje; perdoai-nos as nossas ofensas, assim como nós perdoamos a quem nos tem ofendido; e não nos deixeis cair em tentação, mas livrai-nos do mal. Amém.',
-    latin:
-      'Pater noster, qui es in caelis, sanctificetur nomen tuum; adveniat regnum tuum; fiat voluntas tua, sicut in caelo et in terra. Panem nostrum quotidianum da nobis hodie; et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris; et ne nos inducas in tentationem; sed libera nos a malo. Amen.',
-  },
-  {
-    id: 'ave-maria',
-    title: 'Ave-Maria',
-    portuguese:
-      'Ave Maria, cheia de graça, o Senhor é convosco; bendita sois vós entre as mulheres, e bendito é o fruto do vosso ventre, Jesus. Santa Maria, Mãe de Deus, rogai por nós, pecadores, agora e na hora de nossa morte. Amém.',
-    latin:
-      'Ave Maria, gratia plena, Dominus tecum; benedicta tu in mulieribus, et benedictus fructus ventris tui, Iesus. Sancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.',
-  },
-  {
-    id: 'gloria-patri',
-    title: 'Glória ao Pai (Gloria Patri)',
-    portuguese:
-      'Glória ao Pai, ao Filho e ao Espírito Santo. Como era no princípio, agora e sempre. Amém.',
-    latin:
-      'Gloria Patri, et Filio, et Spiritui Sancto. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.',
-  },
-];
-
 const rosarySequence: PrayerSequence = {
   id: 'dominican-rosary',
   name: 'Santo Rosário',
@@ -226,9 +183,6 @@ export default function RosaryScreen() {
         </ThemedText>
       </ThemedView>
 
-      <PrayerBeadTracker sequence={rosarySequence} />
-      <PrayerBeadTracker sequence={divineMercySequence} />
-
       <ThemedView style={styles.section}>
         <ThemedText
           type="subtitle"
@@ -244,52 +198,8 @@ export default function RosaryScreen() {
         <RosaryMysteryTracker sets={dailyMysteries} />
       </ThemedView>
 
-      <ThemedView style={styles.section}>
-        <ThemedText
-          type="subtitle"
-          style={[styles.sectionTitle, { fontFamily: Fonts.serif }]}
-        >
-          Orações em Português e Latim
-        </ThemedText>
-        <ThemedText style={styles.sectionDescription}>
-          Reze nas duas línguas tradicionais da Igreja: memorize, acompanhe o áudio do seu
-          diretor espiritual ou partilhe com o seu grupo de oração.
-        </ThemedText>
-
-        {bilingualPrayers.map((prayer) => (
-          <ThemedView
-            key={prayer.id}
-            style={styles.prayerCard}
-            lightColor="#F2F7F5"
-            darkColor="#0F1D1A"
-          >
-            <ThemedText
-              type="subtitle"
-              style={[styles.prayerTitle, { fontFamily: Fonts.serif }]}
-            >
-              {prayer.title}
-            </ThemedText>
-
-            <ThemedText
-              style={styles.languageLabel}
-              lightColor="#356859"
-              darkColor="#9FE2BF"
-            >
-              Português
-            </ThemedText>
-            <ThemedText style={styles.prayerText}>{prayer.portuguese}</ThemedText>
-
-            <ThemedText
-              style={styles.languageLabel}
-              lightColor="#356859"
-              darkColor="#9FE2BF"
-            >
-              Latim
-            </ThemedText>
-            <ThemedText style={styles.prayerText}>{prayer.latin}</ThemedText>
-          </ThemedView>
-        ))}
-      </ThemedView>
+      <PrayerBeadTracker sequence={rosarySequence} />
+      <PrayerBeadTracker sequence={divineMercySequence} />
     </ParallaxScrollView>
   );
 }
@@ -319,23 +229,6 @@ const styles = StyleSheet.create({
     fontSize: 22,
   },
   sectionDescription: {
-    lineHeight: 22,
-  },
-  prayerCard: {
-    padding: 18,
-    borderRadius: 16,
-    gap: 8,
-  },
-  prayerTitle: {
-    fontSize: 18,
-  },
-  languageLabel: {
-    fontSize: 12,
-    fontWeight: '700',
-    letterSpacing: 1,
-    textTransform: 'uppercase',
-  },
-  prayerText: {
     lineHeight: 22,
   },
 });

--- a/constants/bilingual-prayers.ts
+++ b/constants/bilingual-prayers.ts
@@ -1,0 +1,49 @@
+export type BilingualPrayer = {
+  id: string;
+  title: string;
+  portuguese: string;
+  latin: string;
+};
+
+export const bilingualPrayers: BilingualPrayer[] = [
+  {
+    id: 'salve-rainha',
+    title: 'Salve Rainha',
+    portuguese:
+      'Salve, Rainha, Mãe de misericórdia; vida, doçura e esperança nossa, salve. A vós bradamos, os degredados filhos de Eva. A vós suspiramos, gemendo e chorando neste vale de lágrimas. Eia, pois, advogada nossa, esses vossos olhos misericordiosos a nós volvei. E depois deste desterro, mostrai-nos Jesus, bendito fruto do vosso ventre. Ó clemente, ó piedosa, ó doce sempre Virgem Maria. Rogai por nós, santa Mãe de Deus, para que sejamos dignos das promessas de Cristo. Amém.',
+    latin:
+      'Salve, Regina, mater misericordiae; vita, dulcedo, et spes nostra, salve. Ad te clamamus, exsules filii Hevae. Ad te suspiramus, gementes et flentes in hac lacrimarum valle. Eia ergo, advocata nostra, illos tuos misericordes oculos ad nos converte. Et Iesum, benedictum fructum ventris tui, nobis post hoc exsilium ostende. O clemens, O pia, O dulcis Virgo Maria. Ora pro nobis, sancta Dei Genetrix, ut digni efficiamur promissionibus Christi. Amen.',
+  },
+  {
+    id: 'magnificat',
+    title: 'Magnificat',
+    portuguese:
+      'A minha alma engrandece o Senhor, e o meu espírito se alegra em Deus, meu Salvador; porque olhou para a humildade de sua serva; doravante todas as gerações me chamarão bem-aventurada; porque o Poderoso fez em mim maravilhas, e Santo é o seu nome. Sua misericórdia se estende, de geração em geração, sobre os que o temem. Manifestou o poder do seu braço: dispersou os soberbos de coração. Derrubou do trono os poderosos e exaltou os humildes. Encheu de bens os famintos, e despediu os ricos de mãos vazias. Acolheu Israel, seu servo, lembrado de sua misericórdia, conforme prometera aos nossos pais, em favor de Abraão e de sua descendência, para sempre. Amém.',
+    latin:
+      'Magnificat anima mea Dominum; et exsultavit spiritus meus in Deo salutari meo, quia respexit humilitatem ancillae suae. Ecce enim ex hoc beatam me dicent omnes generationes, quia fecit mihi magna qui potens est, et sanctum nomen eius, et misericordia eius in progenies et progenies timentibus eum. Fecit potentiam in brachio suo; dispersit superbos mente cordis sui. Deposuit potentes de sede et exaltavit humiles. Esurientes implevit bonis et divites dimisit inanes. Suscepit Israel puerum suum, recordatus misericordiae suae, sicut locutus est ad patres nostros, Abraham et semini eius in saecula. Amen.',
+  },
+  {
+    id: 'pater-noster',
+    title: 'Pai-Nosso (Pater Noster)',
+    portuguese:
+      'Pai nosso que estais no céu, santificado seja o vosso nome; venha a nós o vosso reino; seja feita a vossa vontade, assim na terra como no céu; o pão nosso de cada dia nos dai hoje; perdoai-nos as nossas ofensas, assim como nós perdoamos a quem nos tem ofendido; e não nos deixeis cair em tentação, mas livrai-nos do mal. Amém.',
+    latin:
+      'Pater noster, qui es in caelis, sanctificetur nomen tuum; adveniat regnum tuum; fiat voluntas tua, sicut in caelo et in terra. Panem nostrum quotidianum da nobis hodie; et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris; et ne nos inducas in tentationem; sed libera nos a malo. Amen.',
+  },
+  {
+    id: 'ave-maria',
+    title: 'Ave-Maria',
+    portuguese:
+      'Ave Maria, cheia de graça, o Senhor é convosco; bendita sois vós entre as mulheres, e bendito é o fruto do vosso ventre, Jesus. Santa Maria, Mãe de Deus, rogai por nós, pecadores, agora e na hora de nossa morte. Amém.',
+    latin:
+      'Ave Maria, gratia plena, Dominus tecum; benedicta tu in mulieribus, et benedictus fructus ventris tui, Iesus. Sancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.',
+  },
+  {
+    id: 'gloria-patri',
+    title: 'Glória ao Pai (Gloria Patri)',
+    portuguese:
+      'Glória ao Pai, ao Filho e ao Espírito Santo. Como era no princípio, agora e sempre. Amém.',
+    latin:
+      'Gloria Patri, et Filio, et Spiritui Sancto. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.',
+  },
+];


### PR DESCRIPTION
## Summary
- move the rosary daily mysteries section to the top of the rosary screen
- extract bilingual prayers content and render it from a dedicated prayers tab
- register the new prayers tab in the tab layout configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ef1892924c8327bab01ad880d357ee