### PR TITLE
Fix tab icons layout and mapping

### DIFF
--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -21,6 +21,7 @@ const MAPPING = {
   'circle.grid.3x3.fill': 'apps',
   'bubble.left.and.bubble.right.fill': 'forum',
   'book.fill': 'menu-book',
+  'hands.sparkles.fill': 'self-improvement',
 } as IconMapping;
 
 /**
@@ -40,5 +41,15 @@ export function IconSymbol({
   style?: StyleProp<TextStyle>;
   weight?: SymbolWeight;
 }) {
-  return <MaterialIcons color={color} size={size} name={MAPPING[name]} style={style} />;
+  const iconStyle: StyleProp<TextStyle> = [
+    {
+      height: size,
+      lineHeight: size,
+      textAlign: 'center',
+      width: size,
+    },
+    style,
+  ];
+
+  return <MaterialIcons color={color} size={size} name={MAPPING[name]} style={iconStyle} />;
 }


### PR DESCRIPTION
## Summary
- adjust the shared icon component styling so tab icons render without being clipped
- add the missing Material icon mapping so the prayers tab icon displays on all platforms

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ef1c74006883279420c112d7923b32