### PR TITLE
Add search filter to prayers page

### DIFF
--- a/app/(tabs)/prayers.tsx
+++ b/app/(tabs)/prayers.tsx
@@ -1,13 +1,37 @@
-import { StyleSheet } from 'react-native';
+import { useMemo, useState } from 'react';
+import { StyleSheet, TextInput } from 'react-native';
 
 import ParallaxScrollView from '@/components/parallax-scroll-view';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { bilingualPrayers } from '@/constants/bilingual-prayers';
-import { Fonts } from '@/constants/theme';
+import { Colors, Fonts } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+const normalizeText = (value: string) =>
+  value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
 
 export default function PrayersScreen() {
+  const colorScheme = useColorScheme();
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredPrayers = useMemo(() => {
+    const normalizedQuery = normalizeText(searchQuery.trim());
+
+    if (!normalizedQuery) {
+      return bilingualPrayers;
+    }
+
+    return bilingualPrayers.filter((prayer) => {
+      const combinedText = `${prayer.title}\n${prayer.portuguese}\n${prayer.latin}`;
+      return normalizeText(combinedText).includes(normalizedQuery);
+    });
+  }, [searchQuery]);
+
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: '#F9F6EF', dark: '#1B1A14' }}
@@ -29,39 +53,73 @@ export default function PrayersScreen() {
         </ThemedText>
       </ThemedView>
 
-      {bilingualPrayers.map((prayer) => (
-        <ThemedView
-          key={prayer.id}
-          style={styles.prayerCard}
-          lightColor="#F2F7F5"
-          darkColor="#0F1D1A"
-        >
-          <ThemedText
-            type="subtitle"
-            style={[styles.prayerTitle, { fontFamily: Fonts.serif }]}
-          >
-            {prayer.title}
-          </ThemedText>
+      <ThemedView
+        style={styles.searchContainer}
+        lightColor="#FFFFFF"
+        darkColor="#111312"
+      >
+        <TextInput
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+          placeholder="Busque por título ou trecho"
+          placeholderTextColor={
+            colorScheme === 'dark' ? '#9BA1A6' : '#687076'
+          }
+          selectionColor={colorScheme === 'dark' ? Colors.dark.tint : Colors.light.tint}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="search"
+          style={[
+            styles.searchInput,
+            {
+              color: colorScheme === 'dark' ? Colors.dark.text : Colors.light.text,
+            },
+          ]}
+          accessibilityLabel="Buscar orações"
+        />
+      </ThemedView>
 
-          <ThemedText
-            style={styles.languageLabel}
-            lightColor="#356859"
-            darkColor="#9FE2BF"
-          >
-            Português
+      {filteredPrayers.length === 0 ? (
+        <ThemedView style={styles.emptyState}>
+          <ThemedText style={styles.emptyStateText}>
+            Nenhuma oração encontrada. Ajuste sua busca e tente novamente.
           </ThemedText>
-          <ThemedText style={styles.prayerText}>{prayer.portuguese}</ThemedText>
-
-          <ThemedText
-            style={styles.languageLabel}
-            lightColor="#356859"
-            darkColor="#9FE2BF"
-          >
-            Latim
-          </ThemedText>
-          <ThemedText style={styles.prayerText}>{prayer.latin}</ThemedText>
         </ThemedView>
-      ))}
+      ) : (
+        filteredPrayers.map((prayer) => (
+          <ThemedView
+            key={prayer.id}
+            style={styles.prayerCard}
+            lightColor="#F2F7F5"
+            darkColor="#0F1D1A"
+          >
+            <ThemedText
+              type="subtitle"
+              style={[styles.prayerTitle, { fontFamily: Fonts.serif }]}
+            >
+              {prayer.title}
+            </ThemedText>
+
+            <ThemedText
+              style={styles.languageLabel}
+              lightColor="#356859"
+              darkColor="#9FE2BF"
+            >
+              Português
+            </ThemedText>
+            <ThemedText style={styles.prayerText}>{prayer.portuguese}</ThemedText>
+
+            <ThemedText
+              style={styles.languageLabel}
+              lightColor="#356859"
+              darkColor="#9FE2BF"
+            >
+              Latim
+            </ThemedText>
+            <ThemedText style={styles.prayerText}>{prayer.latin}</ThemedText>
+          </ThemedView>
+        ))
+      )}
     </ParallaxScrollView>
   );
 }
@@ -99,6 +157,26 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   prayerText: {
+    lineHeight: 22,
+  },
+  searchContainer: {
+    borderRadius: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginBottom: 12,
+  },
+  searchInput: {
+    fontSize: 16,
+  },
+  emptyState: {
+    marginTop: 24,
+    padding: 18,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyStateText: {
+    textAlign: 'center',
     lineHeight: 22,
   },
 });


### PR DESCRIPTION
## Summary
- add a themed search input to the prayers screen to filter bilingual prayers by title or content
- normalize the search text to support accent-insensitive matching and present an empty state when no results are found

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ef9d2a31e08327bdbe63c9f4cd64f9