### PR TITLE
Fix chat input background alignment on focus

### DIFF
--- a/app/(tabs)/catechist.tsx
+++ b/app/(tabs)/catechist.tsx
@@ -313,13 +313,15 @@ export default function CatechistScreen() {
     [colorScheme, palette]
   );
 
+  const screenBackground = colorScheme === 'dark' ? '#0f172a' : palette.background;
+
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: screenBackground }}>
       <KeyboardAvoidingView
-        style={{ flex: 1 }}
+        style={{ flex: 1, backgroundColor: screenBackground }}
         behavior={Platform.select({ ios: 'padding', android: undefined })}
         keyboardVerticalOffset={Platform.OS === 'ios' ? 64 : 0}>
-        <ThemedView style={styles.container}>
+        <ThemedView style={[styles.container, { backgroundColor: screenBackground }]}>
           <FlatList
             ref={listRef}
             data={messages}
@@ -335,7 +337,7 @@ export default function CatechistScreen() {
               styles.inputContainer,
               {
                 borderTopColor: colorScheme === 'dark' ? '#1f2937' : '#cbd5f5',
-                backgroundColor: colorScheme === 'dark' ? '#0f172a' : 'transparent',
+                backgroundColor: colorScheme === 'dark' ? '#0f172a' : palette.background,
               },
             ]}>
             <TextInput

--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -238,13 +238,15 @@ export default function ChatScreen() {
     [colorScheme, palette]
   );
 
+  const screenBackground = colorScheme === 'dark' ? '#0f172a' : palette.background;
+
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: screenBackground }}>
       <KeyboardAvoidingView
-        style={{ flex: 1 }}
+        style={{ flex: 1, backgroundColor: screenBackground }}
         behavior={Platform.select({ ios: 'padding', android: undefined })}
         keyboardVerticalOffset={Platform.OS === 'ios' ? 64 : 0}>
-        <ThemedView style={styles.container}>
+        <ThemedView style={[styles.container, { backgroundColor: screenBackground }]}>
           <FlatList
             ref={listRef}
             data={messages}
@@ -260,7 +262,7 @@ export default function ChatScreen() {
               styles.inputContainer,
               {
                 borderTopColor: colorScheme === 'dark' ? '#1f2937' : '#cbd5f5',
-                backgroundColor: colorScheme === 'dark' ? '#0f172a' : 'transparent',
+                backgroundColor: colorScheme === 'dark' ? '#0f172a' : palette.background,
               },
             ]}>
             <TextInput


### PR DESCRIPTION
## Summary
- apply themed background colors to the chat and catechist safe areas so the keyboard reveal keeps the dark styling
- ensure the message input container uses the screen palette in light and dark modes to avoid white flashes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f152b94e9c8327af4c28481ba2b8db