### PR TITLE
Fix notes button contrast and tab labels on web

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,13 +1,16 @@
 import { Tabs } from 'expo-router';
 import React from 'react';
+import { Platform, StyleSheet } from 'react-native';
 
 import { HapticTab } from '@/components/haptic-tab';
+import { ThemedText } from '@/components/themed-text';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
+  const tabBarStyle = Platform.OS === 'web' ? styles.webTabBar : undefined;
 
   return (
     <Tabs
@@ -15,11 +18,13 @@ export default function TabLayout() {
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
         headerShown: false,
         tabBarButton: HapticTab,
+        tabBarStyle,
       }}>
       <Tabs.Screen
         name="index"
         options={{
           title: 'Home',
+          tabBarLabel: ({ color }) => <TabBarLabel color={color} title="Home" />,
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
         }}
       />
@@ -27,6 +32,7 @@ export default function TabLayout() {
         name="rosary"
         options={{
           title: 'Terços',
+          tabBarLabel: ({ color }) => <TabBarLabel color={color} title="Terços" />,
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="circle.grid.3x3.fill" color={color} />,
         }}
       />
@@ -34,6 +40,7 @@ export default function TabLayout() {
         name="prayers"
         options={{
           title: 'Orações',
+          tabBarLabel: ({ color }) => <TabBarLabel color={color} title="Orações" />,
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="hands.sparkles.fill" color={color} />,
         }}
       />
@@ -41,6 +48,7 @@ export default function TabLayout() {
         name="catechist"
         options={{
           title: 'Catequista',
+          tabBarLabel: ({ color }) => <TabBarLabel color={color} title="Catequista" />,
           tabBarIcon: ({ color }) => (
             <IconSymbol size={28} name="book.fill" color={color} />
           ),
@@ -50,6 +58,7 @@ export default function TabLayout() {
         name="chat"
         options={{
           title: 'IA Católica',
+          tabBarLabel: ({ color }) => <TabBarLabel color={color} title="IA Católica" />,
           tabBarIcon: ({ color }) => (
             <IconSymbol size={28} name="bubble.left.and.bubble.right.fill" color={color} />
           ),
@@ -59,6 +68,7 @@ export default function TabLayout() {
         name="notes"
         options={{
           title: 'Anotações',
+          tabBarLabel: ({ color }) => <TabBarLabel color={color} title="Anotações" />,
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="square.and.pencil" color={color} />,
         }}
       />
@@ -66,9 +76,42 @@ export default function TabLayout() {
         name="explore"
         options={{
           title: 'Explore',
+          tabBarLabel: ({ color }) => <TabBarLabel color={color} title="Explore" />,
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
     </Tabs>
   );
 }
+
+type TabBarLabelProps = {
+  color: string;
+  title: string;
+};
+
+function TabBarLabel({ color, title }: TabBarLabelProps) {
+  return (
+    <ThemedText
+      numberOfLines={2}
+      adjustsFontSizeToFit
+      minimumFontScale={0.8}
+      style={[styles.tabLabel, { color }]}
+    >
+      {title}
+    </ThemedText>
+  );
+}
+
+const styles = StyleSheet.create({
+  tabLabel: {
+    fontSize: 12,
+    lineHeight: 16,
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  webTabBar: {
+    paddingTop: 8,
+    paddingBottom: 12,
+    height: 76,
+  },
+});

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -6,7 +6,7 @@
 import { Platform } from 'react-native';
 
 const tintColorLight = '#0a7ea4';
-const tintColorDark = '#fff';
+const tintColorDark = '#38BDF8';
 
 export const Colors = {
   light: {


### PR DESCRIPTION
## Summary
- update the dark theme tint color to keep primary actions legible in the notes screen
- render custom tab bar labels and adjust web spacing so navigation text is no longer clipped in the browser

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f16756f7088327846db04c5c7f8b14