### PR TITLE
Fix Neon Data API query endpoint path

### DIFF
--- a/api/src/lib/neon-client.js
+++ b/api/src/lib/neon-client.js
@@ -48,7 +48,10 @@ class NeonClient {
 
     this.mode = 'data-api';
     this.baseUrl = normalizeBaseUrl(parsed.toString());
-    this.queryEndpoint = new URL('./query', this.baseUrl).toString();
+    // Neon exposes the SQL endpoint one level above the REST base (e.g. /neondb/query),
+    // so we intentionally move up a directory from the /rest/v1 base instead of nesting
+    // under it. Using "./query" would incorrectly target /rest/v1/query and return 404s.
+    this.queryEndpoint = new URL('../query', this.baseUrl).toString();
     this.apiKey = dataApiKey;
   }
 


### PR DESCRIPTION
## Summary
- correct the Neon Data API query endpoint to target the /query path above the /rest/v1 base
- add inline documentation explaining why the relative path must move up one level

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b444c26208327b1da2d2dcef52c3c)