### PR TITLE
Capitalize URL in dailyprayersfunction log

### DIFF
--- a/api/src/functions/dailyprayersfunction.js
+++ b/api/src/functions/dailyprayersfunction.js
@@ -4,7 +4,7 @@ app.http('dailyprayersfunction', {
     methods: ['GET', 'POST'],
     authLevel: 'anonymous',
     handler: async (request, context) => {
-        context.log(`Http function processed request for url "${request.url}"`);
+        context.log(`Http function processed request for URL "${request.url}"`);
 
         const name = request.query.get('name') || await request.text() || 'world';
 


### PR DESCRIPTION
## Summary
- capitalize the URL term in the dailyprayersfunction log message

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b465740bc83279f286e374326fc45)