### PR TITLE
Fix URL capitalization in daily prayers function log

### DIFF
--- a/api/src/functions/dailyprayersfunction.js
+++ b/api/src/functions/dailyprayersfunction.js
@@ -4,7 +4,7 @@ app.http('dailyprayersfunction', {
     methods: ['GET', 'POST'],
     authLevel: 'anonymous',
     handler: async (request, context) => {
-        context.log(`Http function processed request for url "${request.url}"`);
+        context.log(`Http function processed request for URL "${request.url}"`);
 
         const name = request.query.get('name') || await request.text() || 'world';
 


### PR DESCRIPTION
## Summary
- correct log message to spell URL in the dailyprayersfunction handler

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b467d2e948327b89db4f74ebdb33e)