### PR TITLE
Add trailing slash normalization test for chat endpoint

### DIFF
--- a/utils/__tests__/chat-endpoint.test.js
+++ b/utils/__tests__/chat-endpoint.test.js
@@ -49,6 +49,12 @@ describe('resolveChatEndpoint', () => {
     assert.strictEqual(result, 'https://chat.example.com/api/chat');
   });
 
+  it('normalizes trailing slashes in EXPO_PUBLIC_CHAT_BASE_URL', () => {
+    const env = { EXPO_PUBLIC_CHAT_BASE_URL: 'https://chat.example.com/' };
+    const result = resolveChatEndpoint({ env });
+    assert.strictEqual(result, 'https://chat.example.com/api/chat');
+  });
+
   it('falls back to EXPO_PUBLIC_API_BASE_URL when chat base is absent', () => {
     const env = { EXPO_PUBLIC_API_BASE_URL: 'https://api.example.com' };
     const result = resolveChatEndpoint({ env });


### PR DESCRIPTION
## Summary
- add test ensuring chat endpoint normalizes base URLs ending with a trailing slash

## Testing
- npm test -- utils/__tests__/chat-endpoint.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b4652adf08327b6afda68dcc2510d)