### PR TITLE
Fix settings intro text wrapping

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -266,10 +266,7 @@ export default function SettingsScreen() {
           <ThemedText type="title" style={styles.heading}>
             Configurações
           </ThemedText>
-          <ThemedText style={[styles.intro, { color: mutedText }]}>
-            Personalize quais modelos de IA serão utilizados nos assistentes do
-            aplicativo.
-          </ThemedText>
+          <ThemedText style={[styles.intro, { color: mutedText }]}>Personalize quais modelos de IA serão utilizados nos assistentes do aplicativo.</ThemedText>
 
           <View style={styles.section}>
             <ThemedText type="subtitle" style={styles.sectionTitle}>


### PR DESCRIPTION
## Summary
- ensure the settings intro description renders as a single string so wrapping is natural in React Native

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b48eadab08327b689db7701c4fdea)