### PR TITLE
Add coverage for API endpoint utilities

### DIFF
--- a/utils/api-endpoint.ts
+++ b/utils/api-endpoint.ts
@@ -9,7 +9,7 @@ const trim = (value?: string | null) => {
     return null;
   }
 
-  return trimmed.replace(/\/$/, '');
+  return trimmed.replace(/\/+$/, '');
 };
 
 const resolveBase = () => {
@@ -42,7 +42,7 @@ export function buildApiUrl(path: string, baseOverride?: string | null) {
   }
 
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  const sanitizedBase = base.replace(/\/$/, '');
+  const sanitizedBase = base.replace(/\/+$/, '');
 
   if (sanitizedBase.endsWith('/api')) {
     return `${sanitizedBase}${normalizedPath}`;


### PR DESCRIPTION
## Summary
- improve base URL normalization to remove trailing slashes
- add tests covering buildApiUrl and resolveApiBaseUrl edge cases

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b48ed7a788327a6850a56650c1a9c)