### PR TITLE
Use Platform API for iOS haptics

### DIFF
--- a/components/haptic-tab.tsx
+++ b/components/haptic-tab.tsx
@@ -1,13 +1,14 @@
 import { BottomTabBarButtonProps } from '@react-navigation/bottom-tabs';
 import { PlatformPressable } from '@react-navigation/elements';
 import * as Haptics from 'expo-haptics';
+import { Platform } from 'react-native';
 
 export function HapticTab(props: BottomTabBarButtonProps) {
   return (
     <PlatformPressable
       {...props}
       onPressIn={(ev) => {
-        if (process.env.EXPO_OS === 'ios') {
+        if (Platform.OS === 'ios') {
           // Add a soft haptic feedback when pressing down on the tabs.
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         }


### PR DESCRIPTION
## Summary
- update HapticTab to use the React Native Platform API for iOS detection
- keep existing haptic feedback behavior unchanged on other platforms

## Testing
- npm run lint *(fails: expo not found in environment)*
- npx tsc --noEmit *(fails: project tsconfig depends on Expo config and missing node typings in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b48ebde9c83279efdad13bbda0d3b)