### PR TITLE
Add test for buildApiUrl site fallback

### DIFF
--- a/utils/__tests__/api-endpoint.test.js
+++ b/utils/__tests__/api-endpoint.test.js
@@ -99,6 +99,14 @@ describe('buildApiUrl', () => {
     assert.strictEqual(result, 'https://api.example.com/api/prayers/today');
   });
 
+  it('uses the site URL as the final fallback when no override is provided', () => {
+    process.env.EXPO_PUBLIC_SITE_URL = 'https://site.example.com/';
+
+    const result = buildApiUrl('prayers/today');
+
+    assert.strictEqual(result, 'https://site.example.com/api/prayers/today');
+  });
+
   it('returns null when no base URL is available', () => {
     const result = buildApiUrl('prayers/today');
 


### PR DESCRIPTION
## Summary
- add coverage for buildApiUrl using EXPO_PUBLIC_SITE_URL when only site URL is configured
- confirm API path construction uses the site base as the final fallback

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b4b52f38483279dad68e586f9502b)